### PR TITLE
Add stable builds for translations on tag events

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,31 @@
+name: Docs Publish
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [de_DE, ja_JP, ko_KR, pt_BR, fr_FR]
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U virtualenv setuptools wheel
+        pip install -U -r requirements-dev.txt sphinx-intl qiskit
+        sudo apt-get install graphviz pandoc
+    - name: Build and publish
+      env:
+        encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}
+        encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
+        TRANSLATION_LANG: ${{ matrix.language }}
+      run: |
+        tools/deploy_translated_documentation_tag.sh

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,4 +1,4 @@
-name: Docs Publish
+name: Stable Docs Publish
 on:
   push:
     tags:

--- a/tools/deploy_translated_documentation_tag.sh
+++ b/tools/deploy_translated_documentation_tag.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Script for pushing the documentation to the qiskit.org repository.
+
+# Non-travis variables used by this script.
+SOURCE_REPOSITORY="https://github.com/Qiskit/qiskit.git"
+TARGET_DOC_DIR="documentation/locale/"
+SOURCE_DOC_DIR="docs/_build/html/locale"
+SOURCE_DIR=`pwd`
+
+curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
+sudo apt-get install -y ./rclone.deb
+
+RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
+
+set -e
+
+CURRENT_TAG=`git describe --abbrev=0`
+IFS='.'
+read -ra VERSION <<< "$CURRENT_TAG"
+STABLE_VERSION="${VERSION[0]}\.${VERSION[1]}"
+
+# Clone the sources files and po files to $SOURCE_DIR/docs_source
+git clone --depth=1 $SOURCE_REPOSITORY docs_source
+rclone sync -v --exclude='locale/**' docs_source/docs docs
+
+pushd $SOURCE_DIR/docs
+
+# Make translated document
+
+sphinx-build -b html -j auto -D content_prefix=documentation/stable/$STABLE_VERSION -D language=$TRANSLATION_LANG . _build/html/locale/$TRANSLATION_LANG
+
+popd
+
+openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
+
+echo "Pushing built docs to website"
+rclone sync --progress ./docs/_build/html/stable/$STABLE_VERSION/locale/$TRANSLATION_LANG IBMCOS:qiskit-org-web-resources/documentation/stable/$STABLE_VERSION/locale/$TRANSLATION_LANG


### PR DESCRIPTION
This commit adds stable builds on github tag events. Now that we have
stable builds hosted on qiskit.org/documentation (since
Qiskit/qiskit#1261) we can add stable versions of the translations
corresponding to the same releases. This adds a new bash script and gha
ci job to build the documentation on tag events that will have the
proper content prefix set and upload the documentation to
documentation/stable/$VERSION/locale/$LANG (instead of the usual
docuemntation/locale/$LANG). This will correspond with the hosted stable
version of the documentation for any given version and enable users to
read translated documentation for a given minor release corresponding to
the tag.