### PR TITLE
Update job definitions to do a full git checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -9,9 +9,10 @@ jobs:
     strategy:
       matrix:
         language: [de_DE, ja_JP, ko_KR, pt_BR, fr_FR]
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
CI builds are failing because the docs are not doing a full checkout.
Since the introduction of stable versions of the docs we need to have
the git tags fetched locally so we can determine which version string to
to use for the current builds (relative to the stable builds). However
the github actions configuration was doing a shallow clone which
excludes the tags. This causes the job to fail when git describe was
used to determine the working version. This commit fixes this by setting
the config flag in the job definitions to do a full clone which will
have the necessary tags.
